### PR TITLE
Access keys auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ MAC_PLATFORM = x86_64-darwin
 WINDOWS_PLATFORM = x86_64-windows
 
 LDFLAGS := -X github.com/deta/deta-cli/cmd.detaVersion=$(DETA_VERSION) $(LDFLAGS)
+LDFLAGS := -X github.com/deta/deta-cli/cmd.gatewayDomain=$(GATEWAY_DOMAIN) $(LDFLAGS)
+LDFLAGS := -X github.com/deta/deta-cli/cmd.visorURL=$(VISOR_URL) $(LDFLAGS)
 LDFLAGS := -X github.com/deta/deta-cli/auth.loginURL=$(LOGIN_URL) $(LDFLAGS)
 LDFLAGS := -X github.com/deta/deta-cli/auth.cognitoClientID=$(COGNITO_CLIENT_ID) $(LDFLAGS)
 LDFLAGS := -X github.com/deta/deta-cli/auth.cognitoRegion=$(COGNITO_REGION) $(LDFLAGS)
+LDFLAGS := -X github.com/deta/deta-cli/auth.detaSignVersion=$(DETA_SIGN_VERSION) $(LDFLAGS)
 LDFLAGS := -X github.com/deta/deta-cli/api.version=$(DETA_VERSION) $(LDFLAGS)
-LDFLAGS := -X github.com/deta/deta-cli/cmd.gatewayDomain=$(GATEWAY_DOMAIN) $(LDFLAGS)
-LDFLAGS := -X github.com/deta/deta-cli/cmd.visorURL=$(VISOR_URL) $(LDFLAGS)
 
 .PHONY: build clean
 

--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/deta/deta-cli/runtime"
 )
 
 // injects X-Resource-Addr header from account and region
@@ -791,4 +793,25 @@ func (c *DetaClient) GetSchedule(req *GetScheduleRequest) (*GetScheduleResponse,
 		return nil, err
 	}
 	return &resp, nil
+}
+
+// GetUserInfoResponse response to GetUserInfo request
+type GetUserInfoResponse struct {
+	DefaultSpace     int64
+	DefaultSpaceName string
+	DefaultProject   string
+}
+
+// GetUserInfo gets user info
+func (c *DetaClient) GetUserInfo() (*GetUserInfoResponse, error) {
+	resp, err := c.ListSpaces()
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetUserInfoResponse{
+		DefaultSpace:     resp[0].SpaceID,
+		DefaultSpaceName: resp[0].Name,
+		DefaultProject:   runtime.DefaultProject,
+	}, nil
 }

--- a/api/client.go
+++ b/api/client.go
@@ -133,7 +133,7 @@ func (d *DetaClient) request(i *requestInput) (*requestOutput, error) {
 			signature, err := authManager.CalcSignature(&auth.CalcSignatureInput{
 				AccessToken: tokens.DetaAccessToken,
 				HTTPMethod:  i.Method,
-				URL:         req.URL.String(),
+				URI:         req.URL.RequestURI(),
 				Timestamp:   timestamp,
 				ContentType: i.ContentType,
 				RawBody:     marshalled,

--- a/auth/signature.go
+++ b/auth/signature.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+var (
+	// set with Makefile during compilation
+	detaSignVersion string
+)
+
+// CalcSignatureInput input to CalcSignature function
+type CalcSignatureInput struct {
+	AccessToken string
+	HTTPMethod  string
+	URL         string
+	Timestamp   string
+	ContentType string
+	RawBody     []byte
+}
+
+// CalcSignature calculates the signature for signing the requests
+func (m *Manager) CalcSignature(i *CalcSignatureInput) (string, error) {
+	// only v0 for now
+	if detaSignVersion != "v0" {
+		return "", nil
+	}
+
+	tokenParts := strings.Split(i.AccessToken, "_")
+	if len(tokenParts) != 2 {
+		return "", ErrInvalidAccessToken
+	}
+	accessKeyID := tokenParts[0]
+	accessKeySecret := tokenParts[1]
+
+	stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
+		i.HTTPMethod,
+		i.URL,
+		i.Timestamp,
+		i.ContentType,
+		i.RawBody,
+	)
+
+	mac := hmac.New(sha256.New, []byte(accessKeySecret))
+	_, err := mac.Write([]byte(stringToSign))
+	if err != nil {
+		return "", err
+	}
+	signature := mac.Sum(nil)
+	hexSign := hex.EncodeToString(signature)
+
+	return fmt.Sprintf("%s=%s:%s", detaSignVersion, accessKeyID, hexSign), nil
+}

--- a/auth/signature.go
+++ b/auth/signature.go
@@ -17,7 +17,7 @@ var (
 type CalcSignatureInput struct {
 	AccessToken string
 	HTTPMethod  string
-	URL         string
+	URI         string
 	Timestamp   string
 	ContentType string
 	RawBody     []byte
@@ -39,7 +39,7 @@ func (m *Manager) CalcSignature(i *CalcSignatureInput) (string, error) {
 
 	stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
 		i.HTTPMethod,
-		i.URL,
+		i.URI,
 		i.Timestamp,
 		i.ContentType,
 		i.RawBody,

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -83,16 +83,9 @@ func clone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u, err := runtimeManager.GetUserInfo()
+	u, err := getUserInfo(runtimeManager, client)
 	if err != nil {
-		cleanup(wd)
 		return err
-	}
-
-	if u == nil {
-		fmt.Println("login required, log in with `deta login`")
-		cleanup(wd)
-		return nil
 	}
 
 	if projectName == "" {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -24,7 +24,8 @@ func login(cmd *cobra.Command, args []string) error {
 	if err := authManager.Login(); err != nil {
 		return err
 	}
-	resp, err := client.ListSpaces()
+
+	u, err := client.GetUserInfo()
 	if err != nil {
 		return err
 	}
@@ -34,16 +35,11 @@ func login(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u := &runtime.UserInfo{
-		DefaultSpace:     resp[0].SpaceID,
-		DefaultSpaceName: resp[0].Name,
-		DefaultProject:   runtime.DefaultProject,
-	}
-
-	err = runtimeManager.StoreUserInfo(u)
-	if err != nil {
-		return err
-	}
+	runtimeManager.StoreUserInfo(&runtime.UserInfo{
+		DefaultSpace:     u.DefaultSpace,
+		DefaultSpaceName: u.DefaultSpaceName,
+		DefaultProject:   u.DefaultProject,
+	})
 	fmt.Println("Logged in successfully.")
 	return nil
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -127,14 +127,9 @@ func new(cmd *cobra.Command, args []string) error {
 	}
 
 	// get user information
-	userInfo, err := runtimeManager.GetUserInfo()
+	userInfo, err := getUserInfo(runtimeManager, client)
 	if err != nil {
-		fmt.Print("Get user info:", err)
 		return err
-	}
-
-	if userInfo == nil {
-		return fmt.Errorf("login required, log in with 'deta login'")
 	}
 
 	project := userInfo.DefaultProject

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -27,13 +27,9 @@ func listProjects(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	u, err := runtimeManager.GetUserInfo()
+	u, err := getUserInfo(runtimeManager, client)
 	if err != nil {
 		return err
-	}
-
-	if u == nil {
-		return fmt.Errorf("login required, login in `deta login`")
 	}
 
 	res, err := client.GetProjects(&api.GetProjectsRequest{

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/deta/deta-cli/api"
 	"github.com/deta/deta-cli/runtime"
 )
 
@@ -73,4 +74,31 @@ func inSlice(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// get user info from local storage if cached otherwise from server
+// saves user info to local storage if not cached
+func getUserInfo(rm *runtime.Manager, client *api.DetaClient) (*runtime.UserInfo, error) {
+	u, err := rm.GetUserInfo()
+	if err != nil {
+		return nil, err
+	}
+	if u != nil {
+		return u, nil
+	}
+
+	// fall back to server
+	userInfo, err := client.GetUserInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	// save user info
+	u = &runtime.UserInfo{
+		DefaultSpace:     userInfo.DefaultSpace,
+		DefaultSpaceName: userInfo.DefaultSpaceName,
+		DefaultProject:   userInfo.DefaultProject,
+	}
+	go rm.StoreUserInfo(u)
+	return u, nil
 }

--- a/cmd/visor_open.go
+++ b/cmd/visor_open.go
@@ -49,13 +49,9 @@ func visorOpen(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(fmt.Sprintf("no deta micro present in '%s'", wd))
 	}
 
-	userInfo, err := runtimeManager.GetUserInfo()
+	userInfo, err := getUserInfo(runtimeManager, client)
 	if err != nil {
 		return err
-	}
-
-	if userInfo == nil {
-		return fmt.Errorf("login required, login with 'deta login'")
 	}
 
 	progInfo, err := runtimeManager.GetProgInfo()


### PR DESCRIPTION
## Changes
- auth through deta access tokens
    - first priority to JWT tokens
    - fallback to env var `DETA_ACCESS_TOKEN` if no bearer token
    - fallback to access token in `.deta/tokens` file if no env var set
- compute and send signature for each request if auth through deta access tokens
- get user info from server if not cached locally
 


