### PR TITLE
Fix deta watch

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/deta/deta-cli/runtime"
 	"github.com/rjeczalik/notify"
@@ -61,6 +62,7 @@ func watch(cmd *cobra.Command, args []string) error {
 	fmt.Println("Watching changes")
 	for {
 		<-c
+		time.Sleep(100 * time.Millisecond)
 		err := deployChanges(runtimeManager, progInfo, true)
 		if err != nil {
 			return err

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -52,6 +52,12 @@ func watch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// do an initial deployment
+	err = deployChanges(runtimeManager, progInfo, true)
+	if err != nil {
+		return err
+	}
+
 	c := make(chan notify.EventInfo, 1)
 
 	// {dir}/... watch dir recursively


### PR DESCRIPTION
# Changes
- add 100 millisecond delay before deploying on `deta watch` to prevent corrupted deployments (reading file immediately returns no bytes)
- `deta watch` does an initial deployment