### PR TITLE
remove anything after a semicolong to deal with pipenv requirement files

### DIFF
--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -639,6 +639,7 @@ func (m *Manager) readDeps(runtime string) ([]string, error) {
 
 		for _, l := range lines {
 			l = strings.ReplaceAll(l, " ", "")
+			l = strings.Split(l, ";")[0]
 			// skip empty lines and commentes #
 			if l != "" && !strings.HasPrefix(l, "#") {
 				deps = append(deps, l)


### PR DESCRIPTION
This is a pull request to have the deta deploy accept requirements.txt files produced by pipenv