### PR TITLE
fix `.detaignore` bug in windows

### DIFF
--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -341,6 +341,8 @@ func (m *Manager) isHidden(path string) (bool, error) {
 
 // should skip if the file or dir should be skipped
 func (m *Manager) shouldSkip(path string, runtime string) (bool, error) {
+	path = filepath.ToSlash(path)
+
 	// do not skip .detaignore file
 	if regexp.MustCompile(ignoreFile).MatchString(path) {
 		return false, nil

--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -342,12 +342,12 @@ func (m *Manager) isHidden(path string) (bool, error) {
 // should skip if the file or dir should be skipped
 func (m *Manager) shouldSkip(path string, runtime string) (bool, error) {
 	// do not skip .detaignore file
-	if regexp.MustCompile(ignoreFile).MatchString(filepath.ToSlash(path)) {
+	if regexp.MustCompile(ignoreFile).MatchString(path) {
 		return false, nil
 	}
 
 	for _, re := range m.skipPaths[runtime] {
-		if re.Value.MatchString(path) {
+		if re.Value.MatchString(filepath.ToSlash(path)) {
 			return re.Skip, nil
 		}
 	}

--- a/runtime/manager.go
+++ b/runtime/manager.go
@@ -341,10 +341,8 @@ func (m *Manager) isHidden(path string) (bool, error) {
 
 // should skip if the file or dir should be skipped
 func (m *Manager) shouldSkip(path string, runtime string) (bool, error) {
-	path = filepath.ToSlash(path)
-
 	// do not skip .detaignore file
-	if regexp.MustCompile(ignoreFile).MatchString(path) {
+	if regexp.MustCompile(ignoreFile).MatchString(filepath.ToSlash(path)) {
 		return false, nil
 	}
 


### PR DESCRIPTION
Converted path to linux style before comparing. `path = filepath.ToSlash(path)`. 