### PR TITLE
Add: x86-windows build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ LINUX_PLATFORM = x86_64-linux
 LINUX_ARM_PLATFORM= arm64-linux
 MAC_PLATFORM = x86_64-darwin
 MAC_ARM_PLATFORM = arm64-darwin
-WINDOWS_PLATFORM = x86_64-windows
+WINDOWS_PLATFORM_I386 = x86-windows
+WINDOWS_PLATFORM_AMD64 = x86_64-windows
 
 LDFLAGS := -X github.com/deta/deta-cli/cmd.detaVersion=$(DETA_VERSION) $(LDFLAGS)
 LDFLAGS := -X github.com/deta/deta-cli/cmd.gatewayDomain=$(GATEWAY_DOMAIN) $(LDFLAGS)
@@ -26,9 +27,13 @@ build-linux-arm:
 	GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(LINUX_ARM_PLATFORM)" -o build/deta	
 	cd build && zip -FSr deta-$(LINUX_ARM_PLATFORM).zip deta
 
-build-win:
-	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(WINDOWS_PLATFORM)" -o build/deta.exe	
-	cd build && zip -FSr deta-$(WINDOWS_PLATFORM).zip deta.exe
+build-win-i386:
+	GOOS=windows GOARCH=386 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(WINDOWS_PLATFORM_I386)" -o build/deta.exe	
+	cd build && zip -FSr deta-$(WINDOWS_PLATFORM_I386).zip deta.exe
+
+build-win-amd64:
+	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(WINDOWS_PLATFORM_AMD64)" -o build/deta.exe	
+	cd build && zip -FSr deta-$(WINDOWS_PLATFORM_AMD64).zip deta.exe
 
 build-mac:
 	GOOS=darwin GOARCH=amd64 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(MAC_PLATFORM)" -o build/deta	
@@ -38,7 +43,7 @@ build-mac-arm:
 	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -ldflags="$(LDFLAGS) -X github.com/deta/deta-cli/cmd.platform=$(MAC_ARM_PLATFORM)" -o build/deta	
 	cd build && zip -FSr deta-$(MAC_ARM_PLATFORM).zip deta
 
-build: build-linux build-win build-mac build-mac-arm build-linux-arm
+build: build-linux build-win-i386 build-win-amd64 build-mac build-mac-arm build-linux-arm
 
 clean:
 	rm -rf build


### PR DESCRIPTION
With this commit ```make``` will generate **deta-x86-windows.zip** and **deta-x86_64-windows.zip** which will support ARCH=386 and ARCH=amd64 respectively.